### PR TITLE
Add cross nearby graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Implementation of boids using the exported package can be seen [here](https://sp
 - `Array<{ from: number; to: number; distance: number }>` - an array of edges, where each edge contains the indices of two neighboring points and the distance between them.
 
 ```ts
-import { init, createNearByGraph } from "@robertaron/spacial-partitioning";
+import { init, createCrossNearbyGraph, createNearByGraph } from "@robertaron/spacial-partitioning";
 
 // Initialize the WASM module (required before using createNearByGraph)
 await init();
@@ -43,6 +43,23 @@ const neighborGraph = createNearByGraph(positions, distance);
 // [
 //   { from: 0, to: 1, distance: 1.5 },
 //   { from: 1, to: 2, distance: 1.5 },
+// ]
+
+const targetPositions = new Float32Array([
+  0, 0, 0,
+  10, 0, 0,
+]);
+const sourcePositions = new Float32Array([
+  0, 0, 0,
+  1, 0, 0,
+  10, 0, 0,
+]);
+const crossNeighborGraph = createCrossNearbyGraph(targetPositions, sourcePositions, 10);
+// [
+//   { target: 0, source: 0, distance: 0 },
+//   { target: 0, source: 1, distance: 1 },
+//   { target: 1, source: 1, distance: 9 },
+//   { target: 1, source: 2, distance: 0 },
 // ]
 ```
 ---

--- a/packages/npm-package/README.md
+++ b/packages/npm-package/README.md
@@ -22,7 +22,7 @@ npm install @robertaron/spacial-partitioning
 ## Usage
 
 ```js
-import { init, createNearByGraph } from "@robertaron/spacial-partitioning";
+import { init, createCrossNearbyGraph, createNearByGraph } from "@robertaron/spacial-partitioning";
 
 // Initialize the WASM module (required before using createNearByGraph)
 await init();
@@ -39,6 +39,23 @@ const neighborGraph = createNearByGraph(positions, 2);
 //   { from: 0, to: 1, distance: 1.0 },
 //   { from: 2, to: 3, distance: 1.0 },
 // ]
+
+const targetPositions = new Float32Array([
+  0, 0, 0,
+  10, 0, 0,
+]);
+const sourcePositions = new Float32Array([
+  0, 0, 0,
+  1, 0, 0,
+  10, 0, 0,
+]);
+const crossNeighborGraph = createCrossNearbyGraph(targetPositions, sourcePositions, 10);
+// [
+//   { target: 0, source: 0, distance: 0 },
+//   { target: 0, source: 1, distance: 1 },
+//   { target: 1, source: 1, distance: 9 },
+//   { target: 1, source: 2, distance: 0 },
+// ]
 ```
 
 ---
@@ -54,6 +71,13 @@ Initializes the WASM module. **Must be called before using `createNearByGraph`.*
 - `positions`: Flat array of 3D coordinates (x, y, z, x, y, z, ...).
 - `distance`: Maximum distance to consider two points as neighbors.
 - Returns: An array of edges, where each edge contains `from` and `to` (indices of neighboring points) and `distance` (the distance between them).
+
+### `createCrossNearbyGraph(targetPositions: Float32Array, sourcePositions: Float32Array, distance: number): Array<{ target: number; source: number; distance: number }>`
+
+- `targetPositions`: Flat array of target 3D coordinates (x, y, z, x, y, z, ...).
+- `sourcePositions`: Flat array of source 3D coordinates (x, y, z, x, y, z, ...).
+- `distance`: Maximum distance to consider a source point near a target point.
+- Returns: An array of cross-set edges, where each edge contains `target`, `source`, and `distance`.
 
 ---
 

--- a/packages/npm-package/src/index.ts
+++ b/packages/npm-package/src/index.ts
@@ -25,4 +25,28 @@ function createNearByGraph(vec_tuples: Float32Array, distance: number) {
 	return result;
 }
 
-export { init, createNearByGraph };
+function createCrossNearbyGraph(
+	target_tuples: Float32Array,
+	source_tuples: Float32Array,
+	distance: number,
+) {
+	const rawResult = rustLibrary.create_cross_nearby_graph(
+		target_tuples,
+		source_tuples,
+		distance,
+	);
+	const result = new Array<{ target: number; source: number; distance: number }>();
+	for (let i = 0; i < rawResult.length; i += 3) {
+		const target = rawResult[i];
+		const source = rawResult[i + 1];
+		const distance = rawResult[i + 2];
+		result.push({
+			target,
+			source,
+			distance,
+		});
+	}
+	return result;
+}
+
+export { init, createCrossNearbyGraph, createNearByGraph };

--- a/packages/rust-spacial-partitioning/src/lib.rs
+++ b/packages/rust-spacial-partitioning/src/lib.rs
@@ -78,3 +78,63 @@ pub fn create_nearby_graph(vec_tuples: &[f32], distance: f32) -> Vec<f32> {
 
     nearby_lookup
 }
+
+#[wasm_bindgen]
+pub fn create_cross_nearby_graph(target_tuples: &[f32], source_tuples: &[f32], distance: f32) -> Vec<f32> {
+    let targets: Vec<[f32; 3]> = target_tuples
+        .chunks_exact(3)
+        .map(|c| [c[0], c[1], c[2]])
+        .collect();
+    let sources: Vec<[f32; 3]> = source_tuples
+        .chunks_exact(3)
+        .map(|c| [c[0], c[1], c[2]])
+        .collect();
+    let squared_distance = distance * distance;
+    let mut nearby_lookup = Vec::new();
+
+    let mut bucketed_source_indexes: FxHashMap<u64, Vec<usize>> = FxHashMap::default();
+
+    for (i, &[x, y, z]) in sources.iter().enumerate() {
+        let bucket_id = pack_xyz_bits(
+            bucket_value(x, distance),
+            bucket_value(y, distance),
+            bucket_value(z, distance),
+        );
+        bucketed_source_indexes.entry(bucket_id).or_default().push(i);
+    }
+
+    let mut nearish_bucket: SmallVec<[usize; 64]> = SmallVec::new();
+    for (target_index, &[x, y, z]) in targets.iter().enumerate() {
+        nearish_bucket.clear();
+        let bx = bucket_value(x, distance);
+        let by = bucket_value(y, distance);
+        let bz = bucket_value(z, distance);
+
+        for dx in -1..=1 {
+            for dy in -1..=1 {
+                for dz in -1..=1 {
+                    let neighbor_key = pack_xyz_bits(bx + dx, by + dy, bz + dz);
+                    if let Some(neighbors) = bucketed_source_indexes.get(&neighbor_key) {
+                        nearish_bucket.extend(neighbors.iter().copied());
+                    }
+                }
+            }
+        }
+
+        for &source_index in nearish_bucket.iter() {
+            let [source_x, source_y, source_z] = sources[source_index];
+            let dx = source_x - x;
+            let dy = source_y - y;
+            let dz = source_z - z;
+            let dist_sq = dx * dx + dy * dy + dz * dz;
+            if dist_sq < squared_distance {
+                let actual_distance = dist_sq.sqrt();
+                nearby_lookup.push(target_index as f32);
+                nearby_lookup.push(source_index as f32);
+                nearby_lookup.push(actual_distance);
+            }
+        }
+    }
+
+    nearby_lookup
+}

--- a/packages/test-bench/tests/index.test.ts
+++ b/packages/test-bench/tests/index.test.ts
@@ -1,6 +1,7 @@
 import { createNearbyGraph as createNearbyGraphAssembly } from "assemblyscript-spacial-partitioning";
 import {
 	init,
+	createCrossNearbyGraph,
 	createNearByGraph as createNearbyGraphRust,
 } from "@robertaron/spacial-partitioning";
 import { createNearbyGraph as createNearbyGraphTypescript } from "typescript-spacial-partitioning";
@@ -28,6 +29,16 @@ function convertResult(result: ArrayLike<number>) {
 		});
 	}
 	return orderResults(output);
+}
+
+function orderCrossResults(
+	output: { target: number; source: number; distance: number }[],
+) {
+	return output.sort((a, b) => {
+		if (a.target !== b.target) return a.target - b.target;
+		if (a.source !== b.source) return a.source - b.source;
+		return a.distance - b.distance;
+	});
 }
 
 function resultsAreEqual(
@@ -97,6 +108,30 @@ describe("Rust Script Tests", () => {
 		const result = createNearbyGraphRust(input3, 5);
 		expect(result.length).toBe(38877);
 	});
+
+	test("Cross nearby graph", () => {
+		const targets = new Float32Array([0, 0, 0, 10, 0, 0]);
+		const sources = new Float32Array([0, 0, 0, 1, 0, 0, 10, 0, 0, 20, 0, 0]);
+
+		const result = orderCrossResults(createCrossNearbyGraph(targets, sources, 10));
+
+		expect(result).toEqual([
+			{ target: 0, source: 0, distance: 0 },
+			{ target: 0, source: 1, distance: 1 },
+			{ target: 1, source: 1, distance: 9 },
+			{ target: 1, source: 2, distance: 0 },
+		]);
+	});
+
+	test("Cross nearby graph returns no pairs when there are no sources", () => {
+		const targets = new Float32Array([0, 0, 0, 10, 0, 0]);
+		const sources = new Float32Array([]);
+
+		const result = createCrossNearbyGraph(targets, sources, 10);
+
+		expect(result).toEqual([]);
+	});
+
 });
 
 describe("TypeScript Tests", () => {


### PR DESCRIPTION
## Summary
- add a Rust/WASM `create_cross_nearby_graph` export for cross-set neighbor queries
- expose the new function from the npm package as `createCrossNearbyGraph`
- document the API and add focused tests for cross-set pair output

## Why
The existing nearby graph function works well for same-set density, like event-to-event density, but StarWatch’s “Scale by Player Traffic” toggle needs cross-set neighbors: for each event point, find nearby player samples. The old workaround was to concatenate events and players, run `createNearByGraph(events + players)`, then filter down to event-player pairs. That technically works, but it also computes event-event pairs and especially player-player pairs, which are unnecessary and can dominate runtime because player samples are much larger and denser. `createCrossNearbyGraph` avoids that extra work while still returning pairs so StarWatch can aggregate density consistently on its side.

## Validation
- `PATH="$(dirname "$(rustup which rustc --toolchain stable)"):$PATH" bun run build` in `packages/rust-spacial-partitioning`
- `bun run build` in `packages/npm-package`
- `bun run test --run` in `packages/test-bench`
